### PR TITLE
Fixed an issue in visual layout of the settings panel

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -421,7 +421,7 @@ class AddonSettingsPanel(SettingsPanel):
 		self.formatChoices.SetSelection(config.conf["clipContentsDesigner"]["browseableTextFormat"])
 		# Translators: label of a dialog.
 		maxLengthLabel = _("&Maximum number of characters when showing clipboard text in browse mode")
-		self.maxLengthEdit =  sHelper.addLabeledControl(
+		self.maxLengthEdit = sHelper.addLabeledControl(
 			maxLengthLabel,
 			gui.nvdaControls.SelectOnFocusSpinCtrl,
 			min=1,

--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -420,9 +420,13 @@ class AddonSettingsPanel(SettingsPanel):
 		self.formatChoices = sHelper.addLabeledControl(formatLabel, wx.Choice, choices=BROWSEABLETEXT_FORMATS)
 		self.formatChoices.SetSelection(config.conf["clipContentsDesigner"]["browseableTextFormat"])
 		# Translators: label of a dialog.
-		wx.StaticText(self, -1, label=_("&Maximum number of characters when showing clipboard text in browse mode"))
-		self.maxLengthEdit = gui.nvdaControls.SelectOnFocusSpinCtrl(
-			self, min=1, max=1000000, initial=config.conf["clipContentsDesigner"]["maxLengthForBrowseableText"]
+		maxLengthLabel = _("&Maximum number of characters when showing clipboard text in browse mode")
+		self.maxLengthEdit =  sHelper.addLabeledControl(
+			maxLengthLabel,
+			gui.nvdaControls.SelectOnFocusSpinCtrl,
+			min=1,
+			max=1000000,
+			initial=config.conf["clipContentsDesigner"]["maxLengthForBrowseableText"]
 		)
 
 	def postInit(self):


### PR DESCRIPTION

## Link to issue number:

None

### Summary of the issue:

In the settings panel of this add-on, the item "Maximum number of characters when showing clipboard text in browse mode" is located at the top and visually, it overlaps the first item ("Type the string to be used as a separator between contents added to the clipboard.") that is also located at the top of the panel.

### Description of how this pull request fixes the issue:

Located the last item of the settings panel under the other items, taking advantage of the `sHelper.addLabeledControl`method as it was already done for the other items of this panel.

### Testing performed:

* I have installed the add-on and modified the `__init__.py` file in my installed version to test it. I have not tested the add-on generation and installation since unfortunately scons does not work locally due to missing version number in `buildVars.py`. I guess there are GitHub actions here to make the build and generate artefacts and various checks.
* Checked visually that all the items are correctly located in the panel with NVA 2020.4beta3 and NVDA 2019.3.

### Known issues with pull request:

None

### Change log entry:

I do not know if such a minor fix deserve a line in the change log.
