### PR TITLE
Fix bug using emulate copy in browsers

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -257,7 +257,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def copy(self):
 		obj = api.getFocusObject()
 		treeInterceptor = obj.treeInterceptor
-		if isinstance(treeInterceptor, browseMode.BrowseModeDocumentTreeInterceptor):
+		if isinstance(treeInterceptor, browseMode.BrowseModeDocumentTreeInterceptor) and not treeInterceptor.passThrough:
 			treeInterceptor.script_copyToClipboard(None)
 		else:
 			keyName = "control+c" if not isArabicKeyboardLayout() else u"control+ؤ"

--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -256,9 +256,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def copy(self):
 		obj = api.getFocusObject()
-		treeInterceptor = obj.treeInterceptor
-		if isinstance(treeInterceptor, browseMode.BrowseModeDocumentTreeInterceptor) and not treeInterceptor.passThrough:
-			treeInterceptor.script_copyToClipboard(None)
+		tI = obj.treeInterceptor
+		if isinstance(tI, browseMode.BrowseModeDocumentTreeInterceptor) and not tI.passThrough:
+			tI.script_copyToClipboard(None)
 		else:
 			keyName = "control+c" if not isArabicKeyboardLayout() else u"control+ؤ"
 			KeyboardInputGesture.fromName(keyName).send()

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ Notes:
 
 ## Changes for 13.0 
 * Fixed an issue in visual layout of the settings panel, thanks to Cyrille Bougot.
+* Fixed bugs when using emulate copy in browsers if focus mode is active.
 
 ## Changes for 12.0
 * Fixed bugs when using emulate copy in applications like LibreOffice Writer.


### PR DESCRIPTION
## Link to issue number:
Issue #25 
### Summary of the issue:
When emulate copy feature without confirmation is used in browsers with focus mode enabled, text is not copied
### Description of how this pull request fixes the issue:
Ensure that script_copyToClipboard of the browseable document is used just if passThrough is not active.

```
if isinstance(treeInterceptor, browseMode.BrowseModeDocumentTreeInterceptor) and not treeInterceptor.passThrough:
			treeInterceptor.script_copyToClipboard(None)
```
### Testing performed:
Changed __init__.py and tested in Google edit box in Chrome and  Firefox. Also verify that emulate copy feature works properly in LibreOffice Writer documents, since the regression was introduced fixing a bug in Writer.
### Known issues with pull request:
None
### Change log entry:
* Fixed bugs when using emulate copy in browsers if focus mode is active.