### PR TITLE
Change the way in which version number is specified in CI by updating add-on template and taking advantage of the new `version` CLI parameter

### DIFF
--- a/.github/workflows/automaticRelease.yaml
+++ b/.github/workflows/automaticRelease.yaml
@@ -24,18 +24,8 @@ jobs:
         pip install scons markdown
         sudo apt update
         sudo apt install gettext
-    - name: Add add-on version
-      run: |
-        import re
-        with open("buildVars.py", 'r+', encoding='utf-8') as f:
-          text = f.read()
-          text = re.sub(r"\"addon_version\" : .*?,", "\"addon_version\" : \"${{ github.sha }}\",", text)
-          f.seek(0)
-          f.write(text)
-          f.truncate()
-      shell: python 
     - name: Build
-      run: scons
+      run: scons version=${{ github.sha }}
     - name: Automatic release
       uses: marvinpinto/action-automatic-releases@latest
       with:

--- a/.github/workflows/testWithNVDA.yaml
+++ b/.github/workflows/testWithNVDA.yaml
@@ -23,25 +23,15 @@ jobs:
         pip install scons markdown
         sudo apt update
         sudo apt install gettext
-    - name: Add add-on version
-      run: |
-        import re
-        with open("buildVars.py", 'r+', encoding='utf-8') as f:
-          text = f.read()
-          text = re.sub(r"\"addon_version\" : .*?,", "\"addon_version\" : \"${{ github.sha }}\",", text)
-          f.seek(0)
-          f.write(text)
-          f.truncate()
-      shell: python 
     - name: Build add-on
-      run: scons
+      run: scons version=${{ github.sha }}
     - name: Upload add-on
       uses: actions/upload-artifact@v2
       with:
         name: nvda-addon
         path: "*.nvda-addon"
     - name: Build pot
-      run: scons pot
+      run: scons pot version=${{ github.sha }}
     - name: Upload pot
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/upload-on-tag.yaml
+++ b/.github/workflows/upload-on-tag.yaml
@@ -20,23 +20,6 @@ jobs:
         pip install scons markdown
         sudo apt update
         sudo apt install gettext
-    - name: Add add-on version
-      run: |
-        import re
-        with open("buildVars.py", 'r+', encoding='utf-8') as f:
-          text = f.read()
-          version = "${{ github.ref }}".split("/")[-1]
-          text = re.sub(r"\"addon_version\" : .*?,", "\"addon_version\" : \"%s\",", text) % version
-          f.seek(0)
-          f.write(text)
-          f.truncate()
-      shell: python 
-    - name: Push changes
-      run: |
-        git config --global user.name github-actions
-        git config --global user.email github-actions@github.com
-        git commit -a -m "Update buildVars"
-        git push origin HEAD:main
     - name: Build add-on
       run: scons
     - name: Calculate sha256

--- a/buildVars.py
+++ b/buildVars.py
@@ -47,3 +47,15 @@ i18nSources = pythonSources + ["buildVars.py"]
 # Files that will be ignored when building the nvda-addon file
 # Paths are relative to the addon directory, not to the root directory of your addon sources.
 excludedFiles = []
+
+# Base language for the NVDA add-on
+# If your add-on is written in a language other than english, modify this variable.
+# For example, set baseLanguage to "es" if your add-on is primarily written in spanish.
+baseLanguage = "en"
+
+# Markdown extensions for add-on documentation
+# Most add-ons do not require additional Markdown extensions.
+# If you need to add support for markup such as tables, fill out the below list.
+# Extensions string must be of the form "markdown.extensions.extensionName"
+# e.g. "markdown.extensions.tables" to add tables.
+markdownExtensions = []

--- a/sconstruct
+++ b/sconstruct
@@ -1,83 +1,135 @@
 # NVDA add-on template  SCONSTRUCT file
-#Copyright (C) 2012, 2014 Rui Batista <ruiandrebatista@gmail.com>
-#This file is covered by the GNU General Public License.
-#See the file COPYING.txt for more details.
+# Copyright (C) 2012-2021 Rui Batista, Noelia Martinez, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING.txt for more details.
 
+import codecs
 import gettext
 import os
 import os.path
 import zipfile
 import sys
+
+# While names imported below are available by default in every SConscript
+# Linters aren't aware about them.
+# To avoid Flake8 F821 warnings about them they are imported explicitly.
+# When using other  Scons functions please add them to the line below.
+from SCons.Script import BoolVariable, Builder, Copy, Environment, Variables
+
 sys.dont_write_bytecode = True
 
-import buildVars
+# Bytecode should not be written for build vars module to keep the repository root folder clean.
+import buildVars  # NOQA: E402
 
 
 def md2html(source, dest):
 	import markdown
+	# Use extensions if defined.
+	mdExtensions = buildVars.markdownExtensions
 	lang = os.path.basename(os.path.dirname(source)).replace('_', '-')
 	localeLang = os.path.basename(os.path.dirname(source))
 	try:
 		_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[localeLang]).gettext
-		title=u"{0}".format(_(buildVars.addon_info["addon_summary"]))
-	except:
-		title="{0}".format(buildVars.addon_info["addon_summary"]) 
+		summary = _(buildVars.addon_info["addon_summary"])
+	except Exception:
+		summary = buildVars.addon_info["addon_summary"]
+	title = "{addonSummary} {addonVersion}".format(
+		addonSummary=summary, addonVersion=buildVars.addon_info["addon_version"]
+	)
 	headerDic = {
 		"[[!meta title=\"": "# ",
 		"\"]]": " #",
 	}
-	with open(source, 'r', encoding="utf-8") as f:
+	with codecs.open(source, "r", "utf-8") as f:
 		mdText = f.read()
 		for k, v in headerDic.items():
 			mdText = mdText.replace(k, v, 1)
-		htmlText = markdown.markdown(mdText)
-	with open(dest, 'w', encoding="utf-8") as f:
-		f.write("<!DOCTYPE html>\n" +
-			"<html lang=\"%s\">\n" % lang +
-			"<head>\n" +
-			"<meta charset=\"UTF-8\">\n" +
-			"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n" +
-			"<link rel=\"stylesheet\" type=\"text/css\" href=\"../style.css\" media=\"screen\">\n" +
-			"<title>%s</title>\n" % title +
-			"</head>\n<body>\n"
-		)
-		f.write(htmlText)
-		f.write("\n</body>\n</html>")
+		htmlText = markdown.markdown(mdText, extensions=mdExtensions)
+	# Optimization: build resulting HTML text in one go instead of writing parts separately.
+	docText = "\n".join([
+		"<!DOCTYPE html>",
+		"<html lang=\"%s\">" % lang,
+		"<head>",
+		"<meta charset=\"UTF-8\">"
+		"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">",
+		"<link rel=\"stylesheet\" type=\"text/css\" href=\"../style.css\" media=\"screen\">",
+		"<title>%s</title>" % title,
+		"</head>\n<body>",
+		htmlText,
+		"</body>\n</html>"
+	])
+	with codecs.open(dest, "w", "utf-8") as f:
+		f.write(docText)
 
-def generateHelpFiles (source, target, env, for_signature):
-	action = env.Action(lambda target, source, env : md2html(source[0].abspath, target[0].abspath) and None,
-	lambda target, source, env : "Generating %s" % target[0])
-	return action
 
-env = Environment(ENV=os.environ, tools=['gettexttool'])
+def mdTool(env):
+	mdAction = env.Action(
+		lambda target, source, env: md2html(source[0].path, target[0].path),
+		lambda target, source, env: 'Generating % s' % target[0],
+	)
+	mdBuilder = env.Builder(
+		action=mdAction,
+		suffix='.html',
+		src_suffix='.md',
+	)
+	env['BUILDERS']['markdown'] = mdBuilder
+
+
+vars = Variables()
+vars.Add("version", "The version of this build", buildVars.addon_info["addon_version"])
+vars.Add(BoolVariable("dev", "Whether this is a daily development version", False))
+vars.Add("channel", "Update channel for this build", buildVars.addon_info["addon_updateChannel"])
+
+env = Environment(variables=vars, ENV=os.environ, tools=['gettexttool', mdTool])
 env.Append(**buildVars.addon_info)
+
+if env["dev"]:
+	import datetime
+	buildDate = datetime.datetime.now()
+	year, month, day = str(buildDate.year), str(buildDate.month), str(buildDate.day)
+	env["addon_version"] = "".join([year, month.zfill(2), day.zfill(2), "-dev"])
+	env["channel"] = "dev"
+elif env["version"] is not None:
+	env["addon_version"] = env["version"]
+if "channel" in env and env["channel"] is not None:
+	env["addon_updateChannel"] = env["channel"]
+
+buildVars.addon_info["addon_version"] = env["addon_version"]
+buildVars.addon_info["addon_updateChannel"] = env["addon_updateChannel"]
 
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")
 
+
 def addonGenerator(target, source, env, for_signature):
-	action = env.Action(lambda target, source, env : createAddonBundleFromPath(source[0].abspath, target[0].abspath) and None,
-	lambda target, source, env : "Generating Addon %s" % target[0])
+	action = env.Action(
+		lambda target, source, env: createAddonBundleFromPath(source[0].abspath, target[0].abspath) and None,
+		lambda target, source, env: "Generating Addon %s" % target[0]
+	)
 	return action
 
+
 def manifestGenerator(target, source, env, for_signature):
-	action = env.Action(lambda target, source, env : generateManifest(source[0].abspath, target[0].abspath) and None,
-	lambda target, source, env : "Generating manifest %s" % target[0])
+	action = env.Action(
+		lambda target, source, env: generateManifest(source[0].abspath, target[0].abspath) and None,
+		lambda target, source, env: "Generating manifest %s" % target[0]
+	)
 	return action
 
 
 def translatedManifestGenerator(target, source, env, for_signature):
 	dir = os.path.abspath(os.path.join(os.path.dirname(str(source[0])), ".."))
 	lang = os.path.basename(dir)
-	action = env.Action(lambda target, source, env : generateTranslatedManifest(source[1].abspath, lang, target[0].abspath) and None,
-	lambda target, source, env : "Generating translated manifest %s" % target[0])
+	action = env.Action(
+		lambda target, source, env: generateTranslatedManifest(source[1].abspath, lang, target[0].abspath) and None,
+		lambda target, source, env: "Generating translated manifest %s" % target[0]
+	)
 	return action
 
+
 env['BUILDERS']['NVDAAddon'] = Builder(generator=addonGenerator)
-env['BUILDERS']['markdown']=Builder(generator = generateHelpFiles,
-	suffix='.html',
-	src_suffix='.md')
 env['BUILDERS']['NVDAManifest'] = Builder(generator=manifestGenerator)
 env['BUILDERS']['NVDATranslatedManifest'] = Builder(generator=translatedManifestGenerator)
+
 
 def createAddonHelp(dir):
 	docsDir = os.path.join(dir, "doc")
@@ -86,10 +138,9 @@ def createAddonHelp(dir):
 		cssTarget = env.Command(cssPath, "style.css", Copy("$TARGET", "$SOURCE"))
 		env.Depends(addon, cssTarget)
 	if os.path.isfile("readme.md"):
-		readmePath = os.path.join(docsDir, "en", "readme.md")
+		readmePath = os.path.join(docsDir, buildVars.baseLanguage, "readme.md")
 		readmeTarget = env.Command(readmePath, "readme.md", Copy("$TARGET", "$SOURCE"))
 		env.Depends(addon, readmeTarget)
-
 
 
 def createAddonBundleFromPath(path, dest):
@@ -102,49 +153,71 @@ def createAddonBundleFromPath(path, dest):
 			for filename in filenames:
 				pathInBundle = os.path.join(relativePath, filename)
 				absPath = os.path.join(dir, filename)
-				if pathInBundle not in buildVars.excludedFiles: z.write(absPath, pathInBundle)
+				if pathInBundle not in buildVars.excludedFiles:
+					z.write(absPath, pathInBundle)
 	return dest
 
+
 def generateManifest(source, dest):
-	with open(source, 'r', encoding="utf-8") as f:
+	addon_info = buildVars.addon_info
+	with codecs.open(source, "r", "utf-8") as f:
 		manifest_template = f.read()
-	manifest = manifest_template.format(**buildVars.addon_info)
-	with open(dest, 'w', encoding="utf-8") as f:
+	manifest = manifest_template.format(**addon_info)
+	with codecs.open(dest, "w", "utf-8") as f:
 		f.write(manifest)
+
 
 def generateTranslatedManifest(source, language, out):
 	_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[language]).gettext
 	vars = {}
 	for var in ("addon_summary", "addon_description"):
-		if isinstance(buildVars.addon_info[var], str):
-			vars[var] = _(buildVars.addon_info[var])
-		elif isinstance(buildVars.addon_info[var], list):
-			vars[var] = ''.join([_(l) for l in buildVars.addon_info[var]])
-		else:
-			raise TypeError("Error with %s key in buildVars" % var)
-
-	with open(source, 'r', encoding="utf-8") as f:
+		vars[var] = _(buildVars.addon_info[var])
+	with codecs.open(source, "r", "utf-8") as f:
 		manifest_template = f.read()
 	result = manifest_template.format(**vars)
-	with open(out, 'w', encoding="utf-8") as f:
+	with codecs.open(out, "w", "utf-8") as f:
 		f.write(result)
+
 
 def expandGlobs(files):
 	return [f for pattern in files for f in env.Glob(pattern)]
 
+
 addon = env.NVDAAddon(addonFile, env.Dir('addon'))
+
+langDirs = [f for f in env.Glob(os.path.join("addon", "locale", "*"))]
+
+# Allow all NVDA's gettext po files to be compiled in source/locale, and manifest files to be generated
+for dir in langDirs:
+	poFile = dir.File(os.path.join("LC_MESSAGES", "nvda.po"))
+	moFile = env.gettextMoFile(poFile)
+	env.Depends(moFile, poFile)
+	translatedManifest = env.NVDATranslatedManifest(
+		dir.File("manifest.ini"),
+		[moFile, os.path.join("manifest-translated.ini.tpl")]
+	)
+	env.Depends(translatedManifest, ["buildVars.py"])
+	env.Depends(addon, [translatedManifest, moFile])
 
 pythonFiles = expandGlobs(buildVars.pythonSources)
 for file in pythonFiles:
 	env.Depends(addon, file)
 
+# Convert markdown files to html
+# We need at least doc in English and should enable the Help button for the add-on in Add-ons Manager
+createAddonHelp("addon")
+for mdFile in env.Glob(os.path.join('addon', 'doc', '*', '*.md')):
+	htmlFile = env.markdown(mdFile)
+	env.Depends(htmlFile, mdFile)
+	env.Depends(addon, htmlFile)
+
 # Pot target
 i18nFiles = expandGlobs(buildVars.i18nSources)
-gettextvars={
-		'gettext_package_bugs_address' : 'nvda-translations@groups.io',
-		'gettext_package_name' : buildVars.addon_info['addon_name'],
-		'gettext_package_version' : buildVars.addon_info['addon_version']
-	}
+gettextvars = {
+	'gettext_package_bugs_address': 'nvda-translations@groups.io',
+	'gettext_package_name': buildVars.addon_info['addon_name'],
+	'gettext_package_version': buildVars.addon_info['addon_version']
+}
 
 pot = env.gettextPotFile("${addon_name}.pot", i18nFiles, **gettextvars)
 env.Alias('pot', pot)
@@ -159,21 +232,5 @@ manifest = env.NVDAManifest(os.path.join("addon", "manifest.ini"), os.path.join(
 env.Depends(manifest, "buildVars.py")
 
 env.Depends(addon, manifest)
-createAddonHelp("addon") # We need at least doc in English and should enable the Help button for the add-on in Add-ons Manager
-langDirs = [f for f in env.Glob(os.path.join("addon", "locale", "*"))]
-
-#Allow all NVDA's gettext po files to be compiled in source/locale, and manifest files to be generated
-for dir in langDirs:
-	poFile = dir.File(os.path.join("LC_MESSAGES", "nvda.po"))
-	moFile=env.gettextMoFile(poFile)
-	env.Depends(moFile, poFile)
-	translatedManifest = env.NVDATranslatedManifest(dir.File("manifest.ini"), [moFile, os.path.join("manifest-translated.ini.tpl")])
-	env.Depends(translatedManifest, ["buildVars.py"])
-	env.Depends(addon, [translatedManifest, moFile])
-#Convert markdown files to html
-for mdFile in env.Glob(os.path.join('addon', 'doc', '*', '*.md')):
-	htmlFile = env.markdown(mdFile)
-	env.Depends(htmlFile, mdFile)
-	env.Depends(addon, htmlFile)
 env.Default(addon)
-env.Clean (addon, ['.sconsign.dblite', 'addon/doc/en/'])
+env.Clean(addon, ['.sconsign.dblite', 'addon/doc/' + buildVars.baseLanguage + '/'])

--- a/site_scons/site_tools/gettexttool/__init__.py
+++ b/site_scons/site_tools/gettexttool/__init__.py
@@ -17,33 +17,39 @@ To properly configure get text, define the following variables:
 """
 from SCons.Action import Action
 
+
 def exists(env):
 	return True
+
 
 XGETTEXT_COMMON_ARGS = (
 	"--msgid-bugs-address='$gettext_package_bugs_address' "
 	"--package-name='$gettext_package_name' "
 	"--package-version='$gettext_package_version' "
+	"--keyword=pgettext:1c,2 "
 	"-c -o $TARGET $SOURCES"
 )
+
 
 def generate(env):
 	env.SetDefault(gettext_package_bugs_address="example@example.com")
 	env.SetDefault(gettext_package_name="")
 	env.SetDefault(gettext_package_version="")
 
-	env['BUILDERS']['gettextMoFile']=env.Builder(
+	env['BUILDERS']['gettextMoFile'] = env.Builder(
 		action=Action("msgfmt -o $TARGET $SOURCE", "Compiling translation $SOURCE"),
 		suffix=".mo",
 		src_suffix=".po"
 	)
 
-	env['BUILDERS']['gettextPotFile']=env.Builder(
+	env['BUILDERS']['gettextPotFile'] = env.Builder(
 		action=Action("xgettext " + XGETTEXT_COMMON_ARGS, "Generating pot file $TARGET"),
 		suffix=".pot")
 
-	env['BUILDERS']['gettextMergePotFile']=env.Builder(
-		action=Action("xgettext " + "--omit-header --no-location " + XGETTEXT_COMMON_ARGS,
-			"Generating pot file $TARGET"),
-		suffix=".pot")
-
+	env['BUILDERS']['gettextMergePotFile'] = env.Builder(
+		action=Action(
+			"xgettext " + "--omit-header --no-location " + XGETTEXT_COMMON_ARGS,
+			"Generating pot file $TARGET"
+		),
+		suffix=".pot"
+	)


### PR DESCRIPTION
## Link to issue number:
https://github.com/nvdaes/cursorLocator/issues/8

### Summary of the issue:
The way in which version number of the add-on is being specified on CI is suboptimal.

### Description of how this pull request fixes the issue:
- Add-on template has been updated to the latest version - while the diff is pretty big most of it is just linting.
- For the prerelease and test actions the build number is being specified as a command  line param
- As discussed on the above issue changing the build number after the tag is created is quite unusual I've removed this. The flip side is that `buildVars` need to be updated in the tagged commit locally but that should not be a problem

### Testing performed:
Successfully executed `scons` and `scons pot` locally.

### Known issues with pull request:
Not sure if GitHub actions would work

### Change log entry:
No user visible impact