### PR TITLE
Fix bug with NVDA+windows+c

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -215,8 +215,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			ui.message(_("Cannot add"))
 
 	@script(
-		# Translators: message presented in input mode.
 		description=_(
+			# Translators: message presented in input mode.
 			"Retrieves the selected string or the text from the previously set start marker "
 			"up to	and including the current position of the review cursor, and adds it to the clipboard."
 		),


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None

Reported by Dark Count in a [message about bug with add to clipboard command](https://nvda-addons.groups.io/g/nvda-addons/message/17265)

### Summary of the issue:
The command description was triple quoted and this is not supported.
### Description of how this pull request fixes the issue:
Used single quotation (with "), splitting the description in different lines so there aren't linter errors.
### Testing performed:
Tested locally, checking that NVDA+windows+c worksand that the description is presented in the input gestures dialog.
### Known issues with pull request:
None
### Change log entry:
* The command to add text to clipboard is again presented in the input gestures dialog.