### PR TITLE
Prepare for NVDA 2022.1

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # clipContentsDesigner: a global plugin for managing clipboard text
-# Copyright (C) 2012-2019 Noelia Ruiz Martínez, other contributors
+# Copyright (C) 2012-2022 Noelia Ruiz Martínez, other contributors
 # Released under GPL 2
 
 import addonHandler
@@ -152,14 +152,13 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		mathMl = mathPres.getMathMlFromTextInfo(api.getReviewPosition())
 		if not mathMl:
 			obj = api.getNavigatorObject()
-			if obj.role == controlTypes.ROLE_MATH:
+			if obj.role == controlTypes.Role.MATH:
 				try:
 					mathMl = obj.mathMl
 				except (NotImplementedError, LookupError):
 					mathMl = None
 		if not mathMl:
 			return
-		mathPres.ensureInit()
 		if mathPres.brailleProvider:
 			text = mathPres.brailleProvider.getBrailleForMathMl(mathMl)
 			return text
@@ -245,7 +244,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	)
 	def script_add(self, gesture):
 		if (
-			config.conf["clipContentsDesigner"]["confirmToAdd"] and not gui.isInMessageBox
+			config.conf["clipContentsDesigner"]["confirmToAdd"] and not gui.message.isModalMessageBoxActive()
 			and self.requiredFormatInClip()
 		):
 			wx.CallAfter(self.confirmAdd)
@@ -271,7 +270,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def script_clear(self, gesture):
 		if (
 			config.conf["clipContentsDesigner"]["confirmToClear"]
-			and not gui.isInMessageBox and self.requiredFormatInClip()
+			and not gui.message.isModalMessageBoxActive()
 		):
 			wx.CallAfter(self.confirmClear)
 		else:
@@ -308,7 +307,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def script_copy(self, gesture):
 		if (
 			config.conf["clipContentsDesigner"]["confirmToCopy"]
-			and not gui.isInMessageBox and self.requiredFormatInClip()
+			and not gui.message.isModalMessageBoxActive()
+			and self.requiredFormatInClip()
 		):
 			wx.CallAfter(self.confirmCopy)
 		else:
@@ -336,7 +336,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def script_cut(self, gesture):
 		if (
 			config.conf["clipContentsDesigner"]["confirmToCut"]
-			and not gui.isInMessageBox and self.requiredFormatInClip()
+			and not gui.message.isModalMessageBoxActive()
+			and self.requiredFormatInClip()
 		):
 			wx.CallAfter(self.confirmCut)
 		else:

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -1,11 +1,12 @@
 # -*- coding: UTF-8 -*-
 # installTasks for clipContentsDesigner add-on
-# Copyright (C) 2017-2018 Noelia Ruiz Martínez
+# Copyright (C) 2017-2022 Noelia Ruiz Martínez
 # Released under GPL 2
+
+import wx
 
 import addonHandler
 import gui
-import wx
 import inputCore
 import config
 

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description": _("""Add-on for managing clipboard text."""),
 	# version
-	"addon_version": "dump-dev",
+	"addon_version": "",
 	# Author(s)
 	"addon_author": u"Noelia <nrm1977@gmail.com>, Abdel <abdelkrim.bensaid@gmail.com",
 	# URL for the add-on documentation support
@@ -27,9 +27,9 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3")
-	"addon_minimumNVDAVersion": "2019.3.0",
+	"addon_minimumNVDAVersion": "2022.1",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2021.3.1",
+	"addon_lastTestedNVDAVersion": "2022.1",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
The add-on needs to be updated for NVDA 2022.1
### Description of how this pull request fixes the issue:
- Use controlTypes.Role.MATH
- Remove mathPres.ensureInit()
- Use gui.message.isModalMessageBoxActive()

Also, tweaked installTasks reordering imports for linting improvement.
### Testing performed:
None yet, will be tested with generated artifact
### Known issues with pull request:
None
### Change log entry:
* Requires NVDA 2022.1