### PR TITLE
Remove message from getTextToAdd

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -170,8 +170,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				api.getReviewPosition().obj,
 				"_selectThenCopyRange", None
 			) or not api.getReviewPosition().obj._selectThenCopyRange:
-				# Translators: message presented when it's not possible to add text, since no text has been selected.
-				ui.message(_("No text to add"))
 				return
 			newText = api.getReviewPosition().obj._selectThenCopyRange.clipboardText
 		try:


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
When text couldn't be added, two different messages maybe reported but just one is presented in braille. This has been reported privately.
### Description of how this pull request fixes the issue:
Remove a message from getTextToAdd function, that now has the single responsibility of retrieving the text.
### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
None