### PR TITLE
Improve config spec

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -39,7 +39,7 @@ BROWSEABLETEXT_FORMATS: List[str] = [
 RAW_TEXT: str = _("Plain text")
 
 confspec: Dict[str, str] = {
-	"separator": "string(default="")",
+	"separator": "string(default='')",
 	"addTextBefore": "boolean(default=False)",
 	"confirmToAdd": "boolean(default=False)",
 	"confirmToClear": "boolean(default=False)",
@@ -53,10 +53,7 @@ config.conf.spec["clipContentsDesigner"] = confspec
 
 
 def getBookmark() -> str:
-	try:
-		separator = config.conf["clipContentsDesigner"]["separator"]
-	except KeyError:
-		separator = None
+	separator = config.conf["clipContentsDesigner"]["separator"]
 	if not separator:
 		bookmark = "\r\n"
 	else:
@@ -418,10 +415,7 @@ class AddonSettingsPanel(SettingsPanel):
 		# Translators: label of a dialog.
 		setSeparatorLabel = _("Type the string to be used as a &separator between contents added to the clipboard.")
 		self.setSeparatorEdit = sHelper.addLabeledControl(setSeparatorLabel, wx.TextCtrl)
-		try:
-			self.setSeparatorEdit.SetValue(config.conf["clipContentsDesigner"]["separator"])
-		except KeyError:
-			pass
+		self.setSeparatorEdit.SetValue(config.conf["clipContentsDesigner"]["separator"])
 		# Translators: label of a dialog.
 		self.addTextBeforeCheckBox = sHelper.addItem(wx.CheckBox(self, label=_("&Add text before clip data")))
 		self.addTextBeforeCheckBox.SetValue(config.conf["clipContentsDesigner"]["addTextBefore"])


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None. Reported by @CyrilleB79 in https://github.com/nvdaes/pcKbBrl/pull/10#issuecomment-1376389846
### Summary of the issue:
Due to the usage of double quotes for the string separator in the confspec, it was needed to use try... except to avoid issues if the separator was empty.
### Description of how this pull request fixes the issue:
Single quotes have been used for the deault value of the separator.
### Testing performed:
None yet.
### Known issues with pull request:
None.
### Change log entry:
None.