### PR TITLE
Compatibility with NVDA 2023.1

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion": "2022.1",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2022.3",
+	"addon_lastTestedNVDAVersion": "2023.1",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:

### Summary of the issue:
The add-on needs to be updated for compatibility with NVDA 2023.1. 
### Description of how this pull request fixes the issue:
Changed last tested version.
### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
- Compatible with NVDA 2023.1.
