### PR TITLE
Add ability to restore add-on settings to defaults

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -413,6 +413,9 @@ class AddonSettingsPanel(SettingsPanel):
 	def makeSettings(self, settingsSizer):
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: label of a dialog.
+		self.restoreDefaultsButton = sHelper.addItem(wx.Button(self, label=_("Restore defaults")))
+		self.restoreDefaultsButton.Bind(wx.EVT_BUTTON, self.onRestoreDefaults)
+		# Translators: label of a dialog.
 		setSeparatorLabel = _("Type the string to be used as a &separator between contents added to the clipboard.")
 		self.setSeparatorEdit = sHelper.addLabeledControl(setSeparatorLabel, wx.TextCtrl)
 		self.setSeparatorEdit.SetValue(config.conf["clipContentsDesigner"]["separator"])
@@ -472,9 +475,15 @@ class AddonSettingsPanel(SettingsPanel):
 			max=1000000,
 			initial=config.conf["clipContentsDesigner"]["maxLengthForBrowseableText"]
 		)
-
-	def postInit(self):
 		self.setSeparatorEdit.SetFocus()
+
+	def onRestoreDefaults(self, evt):
+		self.setSeparatorEdit.SetValue(config.conf.getConfigValidation(['clipContentsDesigner', 'separator']).default)
+		self.addTextBeforeCheckBox.SetValue(config.conf.getConfigValidation(['clipContentsDesigner', 'addTextBefore']).default)
+		self.confirmList.CheckedItems = []
+		self.confirmRequirementChoices.SetSelection(config.conf.getConfigValidation(['clipContentsDesigner', 'confirmationRequirement']).default)
+		self.formatChoices.SetSelection(config.conf.getConfigValidation(['clipContentsDesigner', 'browseableTextFormat']).default)
+		self.maxLengthEdit.SetValue(config.conf.getConfigValidation(['clipContentsDesigner', 'maxLengthForBrowseableText']).default)
 
 	def onSave(self):
 		config.conf["clipContentsDesigner"]["separator"] = self.setSeparatorEdit.GetValue()

--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -478,12 +478,22 @@ class AddonSettingsPanel(SettingsPanel):
 		self.setSeparatorEdit.SetFocus()
 
 	def onRestoreDefaults(self, evt):
-		self.setSeparatorEdit.SetValue(config.conf.getConfigValidation(['clipContentsDesigner', 'separator']).default)
-		self.addTextBeforeCheckBox.SetValue(config.conf.getConfigValidation(['clipContentsDesigner', 'addTextBefore']).default)
+		self.setSeparatorEdit.SetValue(
+			config.conf.getConfigValidation(['clipContentsDesigner', 'separator']).default
+		)
+		self.addTextBeforeCheckBox.SetValue(
+			config.conf.getConfigValidation(['clipContentsDesigner', 'addTextBefore']).default
+		)
 		self.confirmList.CheckedItems = []
-		self.confirmRequirementChoices.SetSelection(config.conf.getConfigValidation(['clipContentsDesigner', 'confirmationRequirement']).default)
-		self.formatChoices.SetSelection(config.conf.getConfigValidation(['clipContentsDesigner', 'browseableTextFormat']).default)
-		self.maxLengthEdit.SetValue(config.conf.getConfigValidation(['clipContentsDesigner', 'maxLengthForBrowseableText']).default)
+		self.confirmRequirementChoices.SetSelection(
+			config.conf.getConfigValidation(['clipContentsDesigner', 'confirmationRequirement']).default
+		)
+		self.formatChoices.SetSelection(
+			config.conf.getConfigValidation(['clipContentsDesigner', 'browseableTextFormat']).default
+		)
+		self.maxLengthEdit.SetValue(
+			config.conf.getConfigValidation(['clipContentsDesigner', 'maxLengthForBrowseableText']).default
+		)
 
 	def onSave(self):
 		config.conf["clipContentsDesigner"]["separator"] = self.setSeparatorEdit.GetValue()

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ This panel is available from NVDA's menu, Preferences submenu, Settings dialog.
 
 It contains the following controls:
 
+* Restore defaults: Press shift+tab after opening the panel to press this button.
 * Type the string to be used as a separator between contents added to the clipboard: Allows to set a separator which can be used to find the text segments once the entire added text is pasted.
 * Add text before clip data: It's also possible to choose if the added text will be appended or prepended.
 * Select the actions which require previous confirmation: You can choose, for each action available, if it should be performed inmediately or after confirmation. Available actions are: add text, clear clipboard, emulate copy and emulate cut.
@@ -30,6 +31,9 @@ Notes:
 
 *	Confirmations won't be requested when a message box of NVDA is still opened. In those cases, actions will be inmediately performed.
 * Emulate copy and emulate cut commands mean that, when these features are enabled, the add-on will take control of control+c and control+x. This will allow to select if a confirmation should be requested before performing the actions corresponding to these keystrokes.
+
+## Changes for 22.0.0
+* Added a button to restore defaults in the add-on settings panel.
 
 ## Changes for 17.0
 * Compatible with NVDA 2023.1.


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
Sometimes, it may be convenient to restore settings to defaults.
For example, view this topic on the add-ons mailing list:

https://nvda-addons.groups.io/g/nvda-addons/topic/98920151#21825

### Description of how this pull request fixes the issue:
A button has been added to the add-on settings panel to restore defaults.
### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
* Added ability to restore defaults.