### PR TITLE
Disable the global plugin in secure mode

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -5,6 +5,7 @@
 
 import addonHandler
 import globalPluginHandler
+import globalVars
 import api
 import textInfos
 import controlTypes

--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -99,6 +99,13 @@ def getKeyForCut():
 		return "control+x"
 
 
+def disableInSecureMode(decoratedCls):
+	if globalVars.appArgs.secure:
+		return globalPluginHandler.GlobalPlugin
+	return decoratedCls
+
+
+@disableInSecureMode
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	scriptCategory = ADDON_SUMMARY

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ Notes:
 
 ## Changes for 22.0.0
 * Added a button to restore defaults in the add-on settings panel.
+* The add-on cannot be run in secure mode.
 
 ## Changes for 17.0
 * Compatible with NVDA 2023.1.


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
The plugin is not disabled in secure mode.
### Description of how this pull request fixes the issue:
Used a decorator provided by the community.
### Testing performed:
None yet, tested with other add-ons.
### Known issues with pull request:
None.
### Change log entry:
* The add-on cannot be run in secure mode.