### PR TITLE
Prevent the focus to jump in the panel when browsing the category list

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -421,9 +421,6 @@ class AddonSettingsPanel(SettingsPanel):
 	def makeSettings(self, settingsSizer):
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: label of a dialog.
-		self.restoreDefaultsButton = sHelper.addItem(wx.Button(self, label=_("Restore defaults")))
-		self.restoreDefaultsButton.Bind(wx.EVT_BUTTON, self.onRestoreDefaults)
-		# Translators: label of a dialog.
 		setSeparatorLabel = _("Type the string to be used as a &separator between contents added to the clipboard.")
 		self.setSeparatorEdit = sHelper.addLabeledControl(setSeparatorLabel, wx.TextCtrl)
 		self.setSeparatorEdit.SetValue(config.conf["clipContentsDesigner"]["separator"])
@@ -483,6 +480,9 @@ class AddonSettingsPanel(SettingsPanel):
 			max=1000000,
 			initial=config.conf["clipContentsDesigner"]["maxLengthForBrowseableText"]
 		)
+		# Translators: label of a dialog.
+		self.restoreDefaultsButton = sHelper.addItem(wx.Button(self, label=_("Restore defaults")))
+		self.restoreDefaultsButton.Bind(wx.EVT_BUTTON, self.onRestoreDefaults)
 
 	def onRestoreDefaults(self, evt):
 		self.setSeparatorEdit.SetValue(

--- a/readme.md
+++ b/readme.md
@@ -20,13 +20,13 @@ This panel is available from NVDA's menu, Preferences submenu, Settings dialog.
 
 It contains the following controls:
 
-* Restore defaults: Press shift+tab after opening the panel to press this button.
 * Type the string to be used as a separator between contents added to the clipboard: Allows to set a separator which can be used to find the text segments once the entire added text is pasted.
 * Add text before clip data: It's also possible to choose if the added text will be appended or prepended.
 * Select the actions which require previous confirmation: You can choose, for each action available, if it should be performed inmediately or after confirmation. Available actions are: add text, clear clipboard, emulate copy and emulate cut.
 * Request confirmation before performing the selected actions when: You can select if confirmations will be requested always, just if text is contained in the clipboard, or if clipboard is not empty (for example if you've copied a file, not text).
 * Format to show the clipboard text as HTML in browse mode: If you're learning HTML markup language, you may choose Preformatted text in HTML or HTML as shown in a web browser, to have an idea of how your HTML code will be rendered by NVDA in a browser. The difference between preformatted and conventional HTML is that the first option will preserve consecutive spaces and line breaks, and the second one will compact them.  For example, write some HTML tags like h1, h2, li, pre, etc., select and copy the text to clipboard, and use clipContentsDesigner add-on to show the text in a browseable message.
 * Maximum number of characters when showing clipboard text in browse mode: Please, be aware that increasing this limit may produce issues if the clipboard contains large strings of text. The default limit is 100000 characters.
+* Restore defaults.
 
 Notes:
 


### PR DESCRIPTION
### Issue

When browsing the category list with `downArrow` and crossing Clip content designer item, the focus jump in the panel. The user must shift+tab two times to turn back to the list before pressing again `downArrow` to land on the next item in the list.

Moreover this UX is not in line with NVDA native settings panels.

### Solution
Removed the instruction forcing the focus when the panel is created.

### Open discussion
I imagine that this line of code forcing the focus was aimed to set the focus on the first useful item, the first item being a reset button which is less useful.
If you want, I may also put the reset button in the last position in the panel, but it depends on the UX you want. You have two options:
* Keep the reset button first for better discoverability but less useful control first in the dialog
* Put the reset option last to have most useful options first in the dialog but less discoverability of the reset button
You cannot have both.
Just let me know if you want me to move the button.





