### PR TITLE
Use code planned for NVDA 2023.2

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -16,7 +16,8 @@ import config
 import core
 import wx
 import gui
-from gui import SettingsPanel, NVDASettingsDialog, guiHelper
+from gui import guiHelper
+from gui.settingsDialogs import SettingsPanel, NVDASettingsDialog
 from keyboardHandler import KeyboardInputGesture
 from scriptHandler import script
 from logHandler import log
@@ -112,14 +113,14 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	scriptCategory = ADDON_SUMMARY
 
 	def __init__(self):
-		super(globalPluginHandler.GlobalPlugin, self).__init__()
+		super().__init__()
 		NVDASettingsDialog.categoryClasses.append(AddonSettingsPanel)
 
 	def terminate(self):
 		NVDASettingsDialog.categoryClasses.remove(AddonSettingsPanel)
 
 	def onSettings(self, evt):
-		gui.mainFrame._popupSettingsDialog(NVDASettingsDialog, AddonSettingsPanel)
+		gui.mainFrame.popupSettingsDialog(NVDASettingsDialog, AddonSettingsPanel)
 
 	@script(
 		# Translators: message presented in input mode.


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
NVDA 2023.2 has planned changes that should be used in add-ons when appropriate.
### Description of how this pull request fixes the issue:
- Changed imports and use popupSettingsDialog public function.
### Testing performed:
Imports have been tested in the Python console.
### Known issues with pull request:
None
### Change log entry:
* Requires NVDA 2023.2 or later.