### PR TITLE
Import messageBox from gui.message

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -215,7 +215,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		text = self.getTextToAdd()
 		if not text:
 			return
-		if gui.messageBox(
+		if gui.message.messageBox(
 			# Translators: Label of a dialog.
 			_("Please, confirm if you want to add text to the clipboard"),
 			# Translators: Title of a dialog.
@@ -256,7 +256,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			self.performAdd()
 
 	def confirmClear(self):
-		if gui.messageBox(
+		if gui.message.messageBox(
 			# Translators: Label of a dialog.
 			_("Please, confirm if you want to clear the clipboard"),
 			# Translators: Title of a dialog.
@@ -291,7 +291,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def confirmCopy(self):
 		text = self.getSelectedText()
-		if gui.messageBox(
+		if gui.message.messageBox(
 			# Translators: Label of a dialog.
 			_("Please, confirm if you want to copy to the clipboard"),
 			# Translators: Title of a dialog.
@@ -323,7 +323,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		KeyboardInputGesture.fromName(keyName).send()
 
 	def confirmCut(self):
-		if gui.messageBox(
+		if gui.message.messageBox(
 			# Translators: Label of a dialog.
 			_("Please, confirm if you want to cut from the clipboard"),
 			# Translators: Title of a dialog.

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -38,7 +38,7 @@ def onInstall():
 		inputCore.manager.userGestureMap.remove(cutGesture, module, className, cutScriptName)
 	except ValueError:
 		pass
-	if gui.messageBox(
+	if gui.message.messageBox(
 		# Translators: label of a dialog.
 		_("""This add-on allows to confirm if you want to copy and cut, replacing the clipboard contents,
 		when pressing control+c and control+x. This is named Emulate copy and cut.


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Some day, gui.messageBox may not be available.
### Description of how this pull request fixes the issue:
Use gui.message.messageBox.
### Testing performed:
Checked NVDA's code.
### Known issues with pull request:
None
### Change log entry:
None