### PR TITLE
Address the new native copy feature

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -281,16 +281,17 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			self.clearClipboard()
 
 	def copy(self):
+		keyName = getKeyForCopy()
+		gesture = KeyboardInputGesture.fromName(keyName)
 		obj = api.getFocusObject()
 		tI = obj.treeInterceptor
 		if isinstance(tI, browseMode.BrowseModeDocumentTreeInterceptor) and not tI.passThrough:
-			tI.script_copyToClipboard(None)
+			tI.script_copyToClipboard(gesture)
 		else:
-			keyName = getKeyForCopy()
-			KeyboardInputGesture.fromName(keyName).send()
+			gesture.send()
+
 
 	def confirmCopy(self):
-		text = self.getSelectedText()
 		if gui.message.messageBox(
 			# Translators: Label of a dialog.
 			_("Please, confirm if you want to copy to the clipboard"),
@@ -299,10 +300,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			wx.OK | wx.CANCEL
 		) != wx.OK:
 			return
-		if text:
-			api.copyToClip(text)
-		else:
-			core.callLater(200, self.copy)
+		core.callLater(200, self.copy)
 
 	@script(
 		# Translators: message presented in input mode.

--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -290,7 +290,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		else:
 			gesture.send()
 
-
 	def confirmCopy(self):
 		if gui.message.messageBox(
 			# Translators: Label of a dialog.


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
NVDA 2024.1 may add the ability to use the native copy, for now in Firefox, of applications in browse mode. This needs to be addressed in clipContentsDesigner add-on.
### Description of how this pull request fixes the issue:
In the copy method, don't copy the selected text. Instead, at the start of the function, create a variable with the gesture corresponding to the copy script, to be used when browse mode is active, or sent otherwise. The copy method will be called if confirm copy is active.
### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
None.