### PR TITLE
Use secure browseable message, by @CyrilleB79

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -24,6 +24,9 @@ from logHandler import log
 from typing import Callable, Dict, List
 import locale
 
+from .securityUtils import secureBrowseableMessage  # Created by Cyrille (@CyrilleB79)
+
+
 addonHandler.initTranslation()
 _: Callable[[str], str]
 
@@ -373,7 +376,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				browseableText = "<pre>%s</pre>" % text.strip()[:maxLength]
 			else:
 				browseableText = text.strip()[:maxLength]
-			ui.browseableMessage(
+			secureBrowseableMessage(
 				browseableText,
 				# Translators: title of a browseable message.
 				_("Clipboard text ({max}/{current} - {formatForTitle})".format(
@@ -404,7 +407,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			else:
 				maxLength = len(text)
 			browseableText = text.strip()[:maxLength]
-			ui.browseableMessage(
+			secureBrowseableMessage(
 				browseableText,
 				# Translators: title of a browseable message.
 				_("Clipboard text ({max}/{current} - {formatForTitle})".format(

--- a/addon/globalPlugins/clipContentsDesigner/securityUtils.py
+++ b/addon/globalPlugins/clipContentsDesigner/securityUtils.py
@@ -1,0 +1,43 @@
+# -*- coding: UTF-8 -*-
+# NVDA add-on: Character Information
+# Copyright (C) 2024 Cyrille Bougot
+# This file is covered by the GNU General Public License.
+# See the file COPYING.txt for more details.
+
+import ui
+import buildVersion
+
+nvdaTranslations = _
+
+currentVersion = (buildVersion.version_year, buildVersion.version_major, buildVersion.version_minor)
+
+
+def secureBrowseableMessage(message, title=None, isHtml=False):
+	"""Call securely `ui.browseableMessage`.
+
+	`ui.browseableMessage` is impacted by GHSA-xg6w-23rw-39r8
+	(see https://github.com/nvaccess/nvda/security/advisories/GHSA-xg6w-23rw-39r8#event-132994)
+	This function should be used instead if you do not fully control what is passed as title of
+	`ui.browseableMessage`.
+	"""
+
+	if not hasFix_GHSA_xg6w_23rw_39r8():
+		# NVDA <= 2023.3.3
+		if title is None:
+			# The translation of NVDA's ui.browseableMessage title
+			titleToCheck = nvdaTranslations("NVDA Message")
+		else:
+			titleToCheck = title
+		if currentVersion < (2023, 1, 0):
+			# Before #14668 (NVDA < 2023.1)
+			sep = ";"
+		else:
+			sep = "__NVDA:split-here__"
+		if sep in titleToCheck:
+			raise RuntimeError('"{sep}" not allowed in the title of browseable messages'.format(sep=sep))
+	return ui.browseableMessage(message, title, isHtml)
+
+
+def hasFix_GHSA_xg6w_23rw_39r8():
+	fixedVersion = (2023, 3, 3)
+	return currentVersion >= fixedVersion

--- a/addon/globalPlugins/clipContentsDesigner/securityUtils.py
+++ b/addon/globalPlugins/clipContentsDesigner/securityUtils.py
@@ -6,6 +6,7 @@
 
 import ui
 import buildVersion
+from typing import Callable
 
 _: Callable[[str], str]
 

--- a/addon/globalPlugins/clipContentsDesigner/securityUtils.py
+++ b/addon/globalPlugins/clipContentsDesigner/securityUtils.py
@@ -7,6 +7,8 @@
 import ui
 import buildVersion
 
+_: Callable[[str], str]
+
 nvdaTranslations = _
 
 currentVersion = (buildVersion.version_year, buildVersion.version_major, buildVersion.version_minor)


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:

https://github.com/nvaccess/nvda/security/advisories/GHSA-xg6w-23rw-39r8

### Description of how this pull request fixes the issue:

Use secureBrowseableMessage function, provided by @CyrilleB79.

### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
None.