### PR TITLE
Fix emulate copy for hebreu keyboard

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -87,6 +87,8 @@ def getKeyForCopy():
 		return "control+ز"
 	elif keyboardLayout.startswith("ar_"):
 		return "control+ؤ"
+	elif keyboardLayout.startswith("he_"):
+		return "control+ב"
 	else:
 		return "control+c"
 


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None.
Reported on the user mailing list by Moti:

https://nvda.groups.io/g/nvda/topic/107976333#msg120375

### Summary of the issue:
Emulate copy feature cannot be used with hebreu keyboard.
### Description of how this pull request fixes the issue:
control+ב has been added as the gesture for the emulate copy feature when hebreu keyboard is used.
### Testing performed:
Tested manually with hebreu keyboard.
### Known issues with pull request:
None
### Change log entry:
* Emulate copy can be used with hebreu keyboard.
