### PR TITLE
Add ability to skip configuration dialog when updating

### DIFF
--- a/addon/globalPlugins/clipContentsDesigner/__init__.py
+++ b/addon/globalPlugins/clipContentsDesigner/__init__.py
@@ -49,6 +49,7 @@ confspec: dict[str, str] = {
 	"confirmationRequirement": "integer(default=0)",
 	"browseableTextFormat": "integer(default=0)",
 	"maxLengthForBrowseableText": "integer(default=100000)",
+	"runOnInstall": "boolean(default=True)",
 }
 config.conf.spec["clipContentsDesigner"] = confspec
 
@@ -503,6 +504,9 @@ class AddonSettingsPanel(SettingsPanel):
 			initial=config.conf["clipContentsDesigner"]["maxLengthForBrowseableText"],
 		)
 		# Translators: label of a dialog.
+		self.runOnInstallCheckBox = sHelper.addItem(wx.CheckBox(self, label=_("Show configuration dialog when &updating")))
+		self.runOnInstallCheckBox.SetValue(config.conf["clipContentsDesigner"]["runOnInstall"])
+		# Translators: label of a dialog.
 		self.restoreDefaultsButton = sHelper.addItem(wx.Button(self, label=_("Restore defaults")))
 		self.restoreDefaultsButton.Bind(wx.EVT_BUTTON, self.onRestoreDefaults)
 
@@ -523,6 +527,9 @@ class AddonSettingsPanel(SettingsPanel):
 		self.maxLengthEdit.SetValue(
 			config.conf.getConfigValidation(["clipContentsDesigner", "maxLengthForBrowseableText"]).default,
 		)
+		self.runOnInstallCheckBox.SetValue(
+			config.conf.getConfigValidation(["clipContentsDesigner", "runOnInstall"]).default,
+		)
 
 	def onSave(self):
 		config.conf["clipContentsDesigner"]["separator"] = self.setSeparatorEdit.GetValue()
@@ -536,3 +543,4 @@ class AddonSettingsPanel(SettingsPanel):
 		)
 		config.conf["clipContentsDesigner"]["browseableTextFormat"] = self.formatChoices.GetSelection()
 		config.conf["clipContentsDesigner"]["maxLengthForBrowseableText"] = self.maxLengthEdit.GetValue()
+		config.conf["clipContentsDesigner"]["runOnInstall"] = self.runOnInstallCheckBox.GetValue()

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -20,11 +20,14 @@ confspec = {
 	"confirmationRequirement": "integer(default=0)",
 	"browseableTextFormat": "integer(default=0)",
 	"maxLengthForBrowseableText": "integer(default=100000)",
+	"runOnInstall": "boolean(default=True)",
 }
 config.conf.spec["clipContentsDesigner"] = confspec
 
 
 def onInstall():
+	if not config.conf["clipContentsDesigner"]["runOnInstall"]:
+		return
 	module = "globalPlugins.clipContentsDesigner"
 	className = "GlobalPlugin"
 	copyGesture = "kb:control+c"

--- a/readme.md
+++ b/readme.md
@@ -24,12 +24,18 @@ It contains the following controls:
 * Request confirmation before performing the selected actions when: You can select if confirmations will be requested always, just if text is contained in the clipboard, or if clipboard is not empty (for example if you've copied a file, not text).
 * Format to show the clipboard text as HTML in browse mode: If you're learning HTML markup language, you may choose Preformatted text in HTML or HTML as shown in a web browser, to have an idea of how your HTML code will be rendered by NVDA in a browser. The difference between preformatted and conventional HTML is that the first option will preserve consecutive spaces and line breaks, and the second one will compact them.  For example, write some HTML tags like h1, h2, li, pre, etc., select and copy the text to clipboard, and use clipContentsDesigner add-on to show the text in a browseable message.
 * Maximum number of characters when showing clipboard text in browse mode: Please, be aware that increasing this limit may produce issues if the clipboard contains large strings of text. The default limit is 100000 characters.
+* Show configuration dialog when updating: Uncheck this if you don't want to see a dialog to configure emulate copy and cut when updating the add-on.
 * Restore defaults.
 
 Notes:
 
 *	Confirmations won't be requested when a message box of NVDA is still opened. In those cases, actions will be inmediately performed.
 * Emulate copy and emulate cut commands mean that, when these features are enabled, the add-on will take control of control+c and control+x. This will allow to select if a confirmation should be requested before performing the actions corresponding to these keystrokes.
+
+
+## Changes for 49.0.0
+* Added a checkbox to decide if a configuration dialog should be shown when the add-on is updated.
+
 
 ## Changes for 46.0.0
 * NVDA will sanitize HTML in browseable messages.


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None, requested privately.
### Summary of the issue:
A message asking about configuration of emulate copy is shown when the add-on is updated. However, users likely Will keep always the same option.
### Description of how this pull request fixes the issue:
Added a checkbox to configure this, and update config spec and installTasks accordingly.
### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
* Added a checkbox to decide if configuration dialog should be shown when updating.